### PR TITLE
Drop class list

### DIFF
--- a/angular-bem.js
+++ b/angular-bem.js
@@ -33,34 +33,19 @@
     return !!~str.indexOf(':');
   }
 
-  var classListSupport = !!document.createElement('div').classList, getClasses, addClass, removeClass;
-  
-  if (classListSupport) {
-    getClasses = function(el) {
-      return Array.prototype.slice.call(el[0].classList);
-    };
 
-    addClass = function(el, cls) {
-      el[0].classList.add(cls);
-    };
+  var getClasses = function(el) {
+    return el[0].className.split(/\s/g);
+  };
 
-    removeClass = function(el, cls) {
-      el[0].classList.remove(cls);
-    };
+  var addClass = function(el, cls) {
+    el.addClass(cls);
+  };
 
-  } else {
-    getClasses = function(el) {
-      return el[0].className.split(/\s/g);
-    };
+  var removeClass = function(el, cls) {
+    el.removeClass(cls);
+  };
 
-    addClass = function(el, cls) {
-      el.addClass(cls);
-    };
-
-    removeClass = function(el, cls) {
-      el.removeClass(cls);
-    };
-  }
 
   function generateClass(blockName, elemName, modName, modValue) {
     modName = modNameHandler(modName);

--- a/angular-bem.js
+++ b/angular-bem.js
@@ -33,11 +33,6 @@
     return !!~str.indexOf(':');
   }
 
-
-  var getClasses = function(el) {
-    return el[0].className.split(/\s/g);
-  };
-
   var addClass = function(el, cls) {
     el.addClass(cls);
   };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -56,8 +56,8 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    // browsers: ['IE'],
-    browsers: ['PhantomJS', 'IE', 'Chrome'],
+    // browsers: ['PhantomJS', 'IE', 'Chrome'],
+    browsers: ['PhantomJS'],
 
 
     // Continuous Integration mode

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -56,7 +56,8 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
+    // browsers: ['IE'],
+    browsers: ['PhantomJS', 'IE', 'Chrome'],
 
 
     // Continuous Integration mode

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "angular-mocks": "^1.2.29",
     "jasmine": "^2.4.1",
     "karma": "^0.13.15",
+    "karma-chrome-launcher": "^2.0.0",
+    "karma-ie-launcher": "^1.0.0",
     "karma-jasmine": "^0.3.6",
     "karma-phantomjs-launcher": "^0.2.1",
     "karma-spec-reporter": "0.0.23",

--- a/tests.js
+++ b/tests.js
@@ -33,10 +33,22 @@ describe('angular-bem', function() {
         compare($el, '<div class="ng-scope tnp-block"></div>');
       });
 
+      // IE can't do this with classList
+      it('insert block name on svg', function () {
+          var $el = compile('<svg block="tnp-svg-block"></svg>')(scope);
+          expect($el.hasClass('tnp-svg-block')).toBe(true);
+      });
+
       it('insert element name', function() {
         var $el = compile('<div block="tnp-block"><div elem="tnp-elem"></div></div>')(scope);
 
         compare($el, '<div class="ng-scope tnp-block"><div class="tnp-block__tnp-elem"></div></div>');
+      });
+
+      it('insert element name on svg', function() {
+        var $el = compile('<svg block="tnp-svg-block"><path elem="tnp-svg-elem"></path></svg>')(scope);
+        expect($el.hasClass('tnp-svg-block')).toBe(true);
+        expect($el.children().hasClass('tnp-svg-block__tnp-svg-elem')).toBe(true);
       });
 
       describe('insert modifiers in block', function() {

--- a/tests.js
+++ b/tests.js
@@ -46,9 +46,12 @@ describe('angular-bem', function() {
       });
 
       it('insert element name on svg', function() {
-        var $el = compile('<svg block="tnp-svg-block"><path elem="tnp-svg-elem"></path></svg>')(scope);
+        var $el = compile(
+          '<svg block="tnp-svg-block"><path elem="tnp-svg-elem"></path></svg>'
+        )(scope);
         expect($el.hasClass('tnp-svg-block')).toBe(true);
-        expect($el.children().hasClass('tnp-svg-block__tnp-svg-elem')).toBe(true);
+        expect($el.children().hasClass('tnp-svg-block__tnp-svg-elem'))
+          .toBe(true);
       });
 
       describe('insert modifiers in block', function() {


### PR DESCRIPTION
This address #17.

While IE supports classList, they don't support it on SVG elements. 
http://caniuse.com/#feat=classlist

This drops the use of classList in favor of the fallback all the time. 